### PR TITLE
로그인, 로그아웃, 로그인 유지 기능 구현 완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-query": "^3.39.3",
         "react-router-dom": "^6.8.0",
         "react-scripts": "5.0.1",
+        "recoil": "^0.7.6",
         "styled-components": "^5.3.6",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -8426,6 +8427,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -14380,6 +14386,25 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.6.tgz",
+      "integrity": "sha512-hsBEw7jFdpBCY/tu2GweiyaqHKxVj6EqF2/SfrglbKvJHhpN57SANWvPW+gE90i3Awi+A5gssOd3u+vWlT+g7g==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/recursive-readdir": {
@@ -23194,6 +23219,11 @@
         "duplexer": "^0.1.2"
       }
     },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -27307,6 +27337,14 @@
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "recoil": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.6.tgz",
+      "integrity": "sha512-hsBEw7jFdpBCY/tu2GweiyaqHKxVj6EqF2/SfrglbKvJHhpN57SANWvPW+gE90i3Awi+A5gssOd3u+vWlT+g7g==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "recursive-readdir": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-query": "^3.39.3",
     "react-router-dom": "^6.8.0",
     "react-scripts": "5.0.1",
+    "recoil": "^0.7.6",
     "styled-components": "^5.3.6",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Outlet } from "react-router-dom";
+import { useRecoilState } from "recoil";
 import styled from "styled-components";
+import { getLoggedInInfo } from "./api/accountApi";
+import { ILoggedInAtom, loggedInAtom } from "./atoms/loggedInAtom";
 
 const Wrapper = styled.div`
   width: 100%;
@@ -8,6 +11,14 @@ const Wrapper = styled.div`
 `;
 
 function App() {
+  const [loggedIn, setLoggedIn] = useRecoilState<ILoggedInAtom>(loggedInAtom);
+  useEffect(() => {
+    getLoggedInInfo().then((res) => {
+      res.data === ""
+        ? setLoggedIn({ isLoggedIn: false, id: "" })
+        : setLoggedIn({ isLoggedIn: true, id: res.data });
+    });
+  }, []);
   return (
     <Wrapper>
       <Outlet />

--- a/src/api/accountApi.ts
+++ b/src/api/accountApi.ts
@@ -6,7 +6,7 @@ import {
   ISignupForm,
 } from "../interfaces/form";
 
-const BASE_URL = "https://229b-175-125-183-151.jp.ngrok.io";
+const BASE_URL = "http://localhost:8080";
 const ID_CHECK_URL = "auth/checkId";
 const SIGNUP_URL = "auth/signup";
 const LOGIN_URL = "auth/login";
@@ -37,6 +37,14 @@ export const loginPost = (loginForm: ILoginForm) =>
     { withCredentials: true }
   );
 
+export const rememberPost = (remember: boolean | undefined) =>
+  axios.post(
+    `${BASE_URL}/auth/autoLogin`,
+    {
+      remember,
+    },
+    { withCredentials: true }
+  );
 export const findIdPost = (findIdForm: IFindIdForm) =>
   axios.post(`${BASE_URL}/${FIND_ID_URL}`, {
     userName: findIdForm.name,
@@ -48,3 +56,6 @@ export const findPasswordPost = (findPasswordForm: IFindPasswordForm) =>
     userId: findPasswordForm.id,
     userEmail: findPasswordForm.email,
   });
+
+export const getLoggedInInfo = () =>
+  axios.get(`${BASE_URL}/isLogin`, { withCredentials: true });

--- a/src/api/accountApi.ts
+++ b/src/api/accountApi.ts
@@ -60,5 +60,5 @@ export const findPasswordPost = (findPasswordForm: IFindPasswordForm) =>
 export const getLoggedInInfo = () =>
   axios.get(`${BASE_URL}/isLogin`, { withCredentials: true });
 
-export const getLogout = () =>
-  axios.get(`${BASE_URL}/auth/logout`, { withCredentials: true });
+export const postLogout = () =>
+  axios.post(`${BASE_URL}/auth/logout`, {}, { withCredentials: true });

--- a/src/api/accountApi.ts
+++ b/src/api/accountApi.ts
@@ -59,3 +59,6 @@ export const findPasswordPost = (findPasswordForm: IFindPasswordForm) =>
 
 export const getLoggedInInfo = () =>
   axios.get(`${BASE_URL}/isLogin`, { withCredentials: true });
+
+export const getLogout = () =>
+  axios.get(`${BASE_URL}/auth/logout`, { withCredentials: true });

--- a/src/atoms/loggedInAtom.ts
+++ b/src/atoms/loggedInAtom.ts
@@ -1,0 +1,14 @@
+import { atom } from "recoil";
+
+export interface ILoggedInAtom {
+  isLoggedIn: boolean;
+  id: string;
+}
+
+export const loggedInAtom = atom<ILoggedInAtom>({
+  key: "loggedIn",
+  default: {
+    isLoggedIn: false,
+    id: "",
+  },
+});

--- a/src/components/MainHeader.tsx
+++ b/src/components/MainHeader.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
-import { getLogout } from "../api/accountApi";
+import { postLogout } from "../api/accountApi";
 import { ILoggedInAtom, loggedInAtom } from "../atoms/loggedInAtom";
 
 const Header = styled.header`
@@ -47,7 +47,7 @@ const MainHeader = () => {
   const navigate = useNavigate();
   const [loggedIn, setLoggedIn] = useRecoilState<ILoggedInAtom>(loggedInAtom);
   const handleLogoutClick = async () => {
-    await getLogout();
+    await postLogout();
     window.location.href = "/";
   };
   return (

--- a/src/components/MainHeader.tsx
+++ b/src/components/MainHeader.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
-import { postLogout } from "../api/accountApi";
+import { getLoggedInInfo, postLogout } from "../api/accountApi";
 import { ILoggedInAtom, loggedInAtom } from "../atoms/loggedInAtom";
 
 const Header = styled.header`
@@ -48,7 +48,11 @@ const MainHeader = () => {
   const [loggedIn, setLoggedIn] = useRecoilState<ILoggedInAtom>(loggedInAtom);
   const handleLogoutClick = async () => {
     await postLogout();
-    window.location.href = "/";
+    await getLoggedInInfo().then((res) => {
+      res.data === ""
+        ? setLoggedIn({ isLoggedIn: false, id: "" })
+        : setLoggedIn({ isLoggedIn: true, id: res.data });
+    });
   };
   return (
     <Header>

--- a/src/components/MainHeader.tsx
+++ b/src/components/MainHeader.tsx
@@ -1,6 +1,9 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { useRecoilState } from "recoil";
 import styled from "styled-components";
+import { getLogout } from "../api/accountApi";
+import { ILoggedInAtom, loggedInAtom } from "../atoms/loggedInAtom";
 
 const Header = styled.header`
   background-color: #e5e5e5;
@@ -42,13 +45,25 @@ const Nav = styled.li`
 
 const MainHeader = () => {
   const navigate = useNavigate();
+  const [loggedIn, setLoggedIn] = useRecoilState<ILoggedInAtom>(loggedInAtom);
+  const handleLogoutClick = async () => {
+    await getLogout();
+    window.location.href = "/";
+  };
   return (
     <Header>
       <TopNav>
-        <NavList>
-          <Nav onClick={() => navigate("/login")}>로그인</Nav>
-          <Nav onClick={() => navigate("/signup")}>회원가입</Nav>
-        </NavList>
+        {loggedIn.isLoggedIn ? (
+          <NavList>
+            <Nav>{loggedIn.id}님</Nav>
+            <Nav onClick={handleLogoutClick}>로그아웃</Nav>
+          </NavList>
+        ) : (
+          <NavList>
+            <Nav onClick={() => navigate("/login")}>로그인</Nav>
+            <Nav onClick={() => navigate("/signup")}>회원가입</Nav>
+          </NavList>
+        )}
       </TopNav>
       <ImgArea>
         <LogoImg onClick={() => navigate("/")} />

--- a/src/components/account/forms/LoginForm.tsx
+++ b/src/components/account/forms/LoginForm.tsx
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import { Input, Label } from "../../../styles/AccountStyles";
 import { Link, useNavigate } from "react-router-dom";
 import { ILoginForm } from "../../../interfaces/form";
-import { loginPost } from "../../../api/accountApi";
+import { loginPost, rememberPost } from "../../../api/accountApi";
 import { useState } from "react";
 
 const Form = styled.form`
@@ -123,7 +123,8 @@ function LoginForm() {
   const { register, handleSubmit } = useForm<ILoginForm>();
   const onValid = async ({ id, password, remember }: ILoginForm) => {
     try {
-      await loginPost({ id, password, remember });
+      await loginPost({ id, password });
+      await rememberPost(remember);
       navigate("/");
     } catch (error) {
       setSubmitFail(true);

--- a/src/components/account/forms/LoginForm.tsx
+++ b/src/components/account/forms/LoginForm.tsx
@@ -1,10 +1,16 @@
 import styled from "styled-components";
 import { useForm } from "react-hook-form";
 import { Input, Label } from "../../../styles/AccountStyles";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { ILoginForm } from "../../../interfaces/form";
-import { loginPost, rememberPost } from "../../../api/accountApi";
+import {
+  getLoggedInInfo,
+  loginPost,
+  rememberPost,
+} from "../../../api/accountApi";
 import { useState } from "react";
+import { useSetRecoilState } from "recoil";
+import { loggedInAtom } from "../../../atoms/loggedInAtom";
 
 const Form = styled.form`
   position: relative;
@@ -119,13 +125,19 @@ const SubmitFail = styled.div`
 
 function LoginForm() {
   const navigate = useNavigate();
+  const setLoggedIn = useSetRecoilState(loggedInAtom);
   const [submitFail, setSubmitFail] = useState(false);
   const { register, handleSubmit } = useForm<ILoginForm>();
   const onValid = async ({ id, password, remember }: ILoginForm) => {
     try {
       await loginPost({ id, password });
       await rememberPost(remember);
-      navigate("/");
+      await getLoggedInInfo().then((res) => {
+        res.data === ""
+          ? setLoggedIn({ isLoggedIn: false, id: "" })
+          : setLoggedIn({ isLoggedIn: true, id: res.data });
+      });
+      navigate(-1);
     } catch (error) {
       setSubmitFail(true);
     }

--- a/src/hooks/useLoggedIn.tsx
+++ b/src/hooks/useLoggedIn.tsx
@@ -1,0 +1,13 @@
+import { useRecoilState } from "recoil";
+import { ILoggedInAtom, loggedInAtom } from "../atoms/loggedInAtom";
+import { useEffect, useState } from "react";
+import { getLoggedInInfo } from "../api/accountApi";
+
+export default function useLoggedIn(data: string) {
+  const [loggedIn, setLoggedIn] = useRecoilState<ILoggedInAtom>(loggedInAtom);
+  data !== ""
+    ? setLoggedIn({ isLoggedIn: true, id: data })
+    : setLoggedIn({ isLoggedIn: false, id: "" });
+
+  return loggedIn;
+}

--- a/src/hooks/useLoggedIn.tsx
+++ b/src/hooks/useLoggedIn.tsx
@@ -1,7 +1,5 @@
 import { useRecoilState } from "recoil";
 import { ILoggedInAtom, loggedInAtom } from "../atoms/loggedInAtom";
-import { useEffect, useState } from "react";
-import { getLoggedInInfo } from "../api/accountApi";
 
 export default function useLoggedIn(data: string) {
   const [loggedIn, setLoggedIn] = useRecoilState<ILoggedInAtom>(loggedInAtom);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import App from "./App";
 import { createGlobalStyle } from "styled-components";
 import { RouterProvider } from "react-router-dom";
 import router from "./Router";
+import { RecoilRoot } from "recoil";
 const GlobalStyle = createGlobalStyle`
  html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
@@ -66,7 +67,9 @@ const root = ReactDOM.createRoot(
 );
 root.render(
   <>
-    <GlobalStyle />
-    <RouterProvider router={router} />
+    <RecoilRoot>
+      <GlobalStyle />
+      <RouterProvider router={router} />
+    </RecoilRoot>
   </>
 );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,7 @@
 import styled from "styled-components";
 import MainHeader from "../components/MainHeader";
+import { useEffect } from "react";
+import { getLoggedInInfo } from "../api/accountApi";
 
 const IntroArea = styled.div`
   display: flex;
@@ -57,6 +59,9 @@ const IntroText = styled.span`
 `;
 
 function Home() {
+  useEffect(() => {
+    getLoggedInInfo().then((res) => console.log(res));
+  }, []);
   return (
     <>
       <MainHeader />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,10 @@
 import styled from "styled-components";
 import MainHeader from "../components/MainHeader";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { getLoggedInInfo } from "../api/accountApi";
+import useLoggedIn from "../hooks/useLoggedIn";
+import { useRecoilState } from "recoil";
+import { ILoggedInAtom, loggedInAtom } from "../atoms/loggedInAtom";
 
 const IntroArea = styled.div`
   display: flex;
@@ -59,9 +62,15 @@ const IntroText = styled.span`
 `;
 
 function Home() {
+  const [loggedIn, setLoggedIn] = useRecoilState<ILoggedInAtom>(loggedInAtom);
   useEffect(() => {
-    getLoggedInInfo().then((res) => console.log(res));
+    getLoggedInInfo().then((res) => {
+      res.data === ""
+        ? setLoggedIn({ isLoggedIn: false, id: "" })
+        : setLoggedIn({ isLoggedIn: true, id: res.data });
+    });
   }, []);
+  console.log(loggedIn);
   return (
     <>
       <MainHeader />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -62,15 +62,6 @@ const IntroText = styled.span`
 `;
 
 function Home() {
-  const [loggedIn, setLoggedIn] = useRecoilState<ILoggedInAtom>(loggedInAtom);
-  useEffect(() => {
-    getLoggedInInfo().then((res) => {
-      res.data === ""
-        ? setLoggedIn({ isLoggedIn: false, id: "" })
-        : setLoggedIn({ isLoggedIn: true, id: res.data });
-    });
-  }, []);
-  console.log(loggedIn);
   return (
     <>
       <MainHeader />


### PR DESCRIPTION
📗 작업 내역
구현 내용 및 작업 내역
* 로그인시 호출할 api 설정
1. loginPost(POST) : SESSION 쿠키 받아옴
2. rememberPost(POST) : 로그인 유지 체크박스 체크했을 시, rememberCookie 가져옴
3. 호출 완료시 로그인 이전 페이지로 이동
* recoil atom으로, 로그인 정보 저장 할 loggedInAtom 생성
* Home 처음 진입시(useEffect), getLoggedInfo(GET) 호출=>로그인한 사용자 아이디 response로 가져옴=>loggedInAtom에 저장
* 로그인 된 상태일 경우 MainHeader 변경=>로그인된 아이디, 로그아웃 버튼 생성
* 로그아웃 버튼 클릭시 postLogout(POST) 호출하여 로그아웃 구현

📘 작업 유형
* 로그인, 로그인 유지, 로그아웃 기능 구현


📝 PR 특이 사항

**🔑 로그인 과정 설명**
아이디, 비밀번호 입력, ‘로그인 유지’ 체크박스 체크 후 로그인 버튼 클릭
➡️ loginPost 호출 후, SESSION 쿠키 받음
➡️ rememberPost 호출 후, 로그인 유지 체크박스 체크했을 시, rememberCookie 받음
➡️ 서버에서 SESSION 쿠키 값을 통해 브라우저가 어떤 유저로 로그인 했는지 기억
➡️ getLoggedInInfo 호출하여 로그인 된 정보가 loggedInAtom에 저장


**🔐 로그인 유지 구현 설명**
router내의 최상위 컴포넌트인 App.tsx 최초 실행
➡️ getLoggedInInfo 호출
➡️ 서버에서 쿠키를 통해 로그인 여부, 로그인 한 유저 식별
➡️ 응답으로 로그인 안된 상태면 “”, 로그인 된 상태면 로그인한 아이디 받음
➡️ loggedInAtom에 이 정보를 저장
➡️ loggedInAtom을 통해 MainHeader에 노출할 내용 선택됨


🔒 로그아웃 과정 설명
MainHeader에 ‘로그아웃’ 클릭
➡️ postLogout 호출
➡️ 쿠키 사라짐
➡️ getLoggedInInfo 호출하여 로그아웃됐다는 정보가 loggedInAtom에 저장
➡️ navigate(-1)

